### PR TITLE
Fix powsybl-core transitive dependencies versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,16 +58,26 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- platform config -->
+        <!-- platform config, tools, core APIs -->
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-config-classic</artifactId>
         </dependency>
-
-        <!-- tools -->
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-tools</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-loadflow-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-security-analysis-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-sensitivity-analysis-api</artifactId>
         </dependency>
 
         <!-- network -->

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <artifactId>powsybl-config-classic</artifactId>
         </dependency>
 
+        <!-- tools -->
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-tools</artifactId>
+        </dependency>
+
         <!-- network -->
         <dependency>
             <groupId>com.powsybl</groupId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`powsybl-tools` is not explicitly defined in the `pom.xml` and is resolved transitively from `powsybl-network-area-diagram`.
In case of patch version of `powsybl-core` this is causing incorrect version of `powsybl-tools` being used.
Today with `powsybl-starter` `v2026.0.0` we get powsybl-tools `v7.2.0` instead of `v7.2.1`.
In particular, this is visible when using `com.powsybl.tools.Version.list()`.

Same issue with following dependencies pulled transitively by `powsybl-open-loadflow`:
- `powsybl-loadflow-api`
- `powsybl-security-analysis-api`
- `powsybl-sensitivity-analysis-api`

**What is the new behavior (if this is a feature change)?**
Add explicitly in `pom.xml`:
- `powsybl-tools`
- `powsybl-loadflow-api`
- `powsybl-security-analysis-api`
- `powsybl-sensitivity-analysis-api`

Note that `powsybl-open-loadflow` today (v2.2.0) also declares `powsybl-loadflow-results-completion` but this will be removed in https://github.com/powsybl/powsybl-open-loadflow/pull/1387

**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

<img width="782" height="840" alt="image" src="https://github.com/user-attachments/assets/5b66c0b7-6452-4b61-a679-7dacd410d578" />
